### PR TITLE
Update date input to recommend accepting month names

### DIFF
--- a/src/components/date-input/index.md
+++ b/src/components/date-input/index.md
@@ -35,6 +35,8 @@ Read more about [why and how to set legends as headings](/get-started/labels-leg
 
 Make sure that any example dates you use in hint text are valid for the question being asked.
 
+You should accept month names written out in full or abbreviated form (for example, ‘january’ or ‘jan’) as some users may enter months in this way.
+
 There are 2 ways to use the date input component. You can use HTML or, if you’re using [Nunjucks](https://mozilla.github.io/nunjucks/) or the [GOV.UK Prototype Kit](https://prototype-kit.service.gov.uk), you can use the Nunjucks macro.
 
 {{ example({group: "components", item: "date-input", example: "default", html: true, nunjucks: true, open: false, size: "s", titleSuffix: "second"}) }}
@@ -155,4 +157,5 @@ Say ‘[whatever it is] must be between [date] and [date and optional descriptio
 
 ## Research on this component
 
-More research is needed to determine the extent to which users struggle to enter months as numbers, and whether allowing them to enter months as text is helpful.
+Data from the ‘Apply for teacher training service‘ showed that hundreds of users were inputting months using full or abbreviated month names, and then getting an error. Some users with dyscalculia may struggle to convert month names into numbers. Since changing the service to accept full or abbreviated month names, the number of errors dramatically dropped. 
+


### PR DESCRIPTION
Back in May 2022, we discovered that hundreds of users were inputting months using full or abbreviated month names in the ‘Apply for teacher training’ service – see [full table of inputs](https://github.com/alphagov/govuk-design-system-backlog/issues/42#issuecomment-1119724868).

We made a change to accept these as valid months which dramatically reduced the number of errors. This change was also later made in another service, ‘Find a lost TRN’.

Given this data and the comments in the backlog thread about people with dyscalculia finding it harder to convert month names into numbers (although possibly most users need at least a second or so to think about this?), it feels like it’s worth adding to the general guidance?

One unresolved open question is about whether this should be advertised, or just be a hidden feature? Arguably the hint text could say something like "For example, 31 8 2005 or 31 aug 2005" to make it clear that both forms are accepted (and avoid people having to do the conversion in their head unnecessarily) but perhaps this just adds confusion?